### PR TITLE
Fix bug with missing items entry

### DIFF
--- a/openapidocs/mk/v3/examples.py
+++ b/openapidocs/mk/v3/examples.py
@@ -117,7 +117,7 @@ class ArrayExampleHandler(SchemaExampleHandler):
             $ref: '#/components/schemas/ReleaseNodeDownload'
           nullable: true
         """
-        items = schema["items"]
+        items = schema.get("items", [])
 
         if not isinstance(items, list):
             items = [items]


### PR DESCRIPTION
Fix this bug, with openapi.jspn  generated by fastapi

![image](https://github.com/Neoteroi/essentials-openapi/assets/66883304/80e8800e-4c92-4dce-beeb-ce41cd28c128)

It seems, like the entry items could be missing. This results in an error accessing the dict.
