### PR TITLE
Add patternProperties to Schema object

### DIFF
--- a/openapidocs/v3.py
+++ b/openapidocs/v3.py
@@ -118,6 +118,7 @@ class Schema(OpenAPIElement):
     format: Union[None, str, ValueFormat] = None
     required: Optional[List[str]] = None
     properties: Optional[Dict[str, Union["Schema", "Reference"]]] = None
+    pattern_properties: Optional[Dict[str, Union["Schema", "Reference"]]] = None
     default: Optional[Any] = None
     deprecated: Optional[bool] = None
     example: Any = None

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -2023,7 +2023,19 @@ class ResponseExample1(TestItem):
     def get_instance(self) -> Any:
         return Response(
             description="A simple string response",
-            content={"text/plain": MediaType(schema=Schema(type="string"))},
+            content={
+                "text/plain": MediaType(schema=Schema(type="string")),
+                "application/json": MediaType(
+                    schema=Schema(
+                        type="object",
+                        pattern_properties={
+                            "^[a-zA-Z0-9_]+$": Schema(
+                                type=ValueType.STRING,
+                            )
+                        },
+                    )
+                ),
+            },
         )
 
     def yaml(self) -> str:
@@ -2033,6 +2045,12 @@ class ResponseExample1(TestItem):
             text/plain:
                 schema:
                     type: string
+            application/json:
+                schema:
+                    type: object
+                    patternProperties:
+                        ^[a-zA-Z0-9_]+$:
+                            type: string
         """
 
     def json(self) -> str:
@@ -2043,6 +2061,16 @@ class ResponseExample1(TestItem):
                 "text/plain": {
                     "schema": {
                         "type": "string"
+                    }
+                },
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "patternProperties": {
+                            "^[a-zA-Z0-9_]+$": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
It will help to support Dict[str, Any] types in the OpenAPI schema.

It is useful to return some grouped data
```python
@dataclass
class User:
    id: str
    name: str
```

Example for `Dict[str, list[User]]`

```json
{
  "type": "object",
  "patternProperties": {
    "^[a-zA-Z0-9_]+$": {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "id": { "type": "string" },
          "name": { "type": "string" }
        },
        "required": ["id", "name"]
      }
    }
  }
}

```