### PR TITLE
Remove wordwrap filters from all templates (issue #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never supported as there was never a `/mk/v2/` namespace, intentionally).
 - Fix [#35](https://github.com/Neoteroi/essentials-openapi/issues/35): group response
   codes in a tab group on MkDocs output, reported by @Andre601.
+- Fix [#47](https://github.com/Neoteroi/essentials-openapi/issues/47): remove `wordwrap`
+  filters from all templates as they break links and mermaid chart code blocks in
+  descriptions, reported by @ElementalWarrior.
 
 ## [1.3.0] - 2025-11-19
 

--- a/openapidocs/mk/v3/views_markdown/partial/components-responses.html
+++ b/openapidocs/mk/v3/views_markdown/partial/components-responses.html
@@ -4,7 +4,7 @@
 {%- for name, definition in components.responses.items() %}
 
 ### {{name}}
-{% if definition.description %}{{definition.description | wordwrap(80)}}{% endif -%}
+{% if definition.description %}{{definition.description}}{% endif -%}
 
 {%- if definition.content -%}
 {% with content = handler.simplify_content(definition.content) -%}

--- a/openapidocs/mk/v3/views_markdown/partial/content-examples.html
+++ b/openapidocs/mk/v3/views_markdown/partial/content-examples.html
@@ -3,6 +3,6 @@
 ```json
 {{handler.write_content_example(example, content_type) | safe}}
 ```
-{% if example.auto_generated %}_{{texts.auto_generated_example_note | wordwrap(80)}}_{% endif -%}
+{% if example.auto_generated %}_{{texts.auto_generated_example_note}}_{% endif -%}
 {% endif %}
 {% endfor %}

--- a/openapidocs/mk/v3/views_markdown/partial/external-docs.html
+++ b/openapidocs/mk/v3/views_markdown/partial/external-docs.html
@@ -1,7 +1,7 @@
 ## {{texts.external_docs}}
 
 {% if externalDocs.description -%}
-{{externalDocs.description | wordwrap(80)}}
+{{externalDocs.description}}
 
 ---
 {% endif -%}

--- a/openapidocs/mk/v3/views_markdown/partial/info.html
+++ b/openapidocs/mk/v3/views_markdown/partial/info.html
@@ -1,7 +1,7 @@
 # {{info.title}} {{info.version}}
 
 {% if info.description -%}
-{{info.description | wordwrap(80)}}
+{{info.description}}
 
 ---
 {% endif -%}

--- a/openapidocs/mk/v3/views_markdown/partial/path-items.html
+++ b/openapidocs/mk/v3/views_markdown/partial/path-items.html
@@ -7,13 +7,13 @@
 
 ### {{http_method.upper()}} {{path | safe}}
 {% if "summary" in operation -%}
-{{operation.summary | wordwrap(80)}}
+{{operation.summary}}
 {%- endif -%}
 
 {%- if operation.description and operation.summary != operation.description %}
 
 **{{texts.description.title()}}**
-{{operation.description | wordwrap(80)}}
+{{operation.description}}
 
 {%- endif -%}
 

--- a/openapidocs/mk/v3/views_mkdocs/partial/components-responses.html
+++ b/openapidocs/mk/v3/views_mkdocs/partial/components-responses.html
@@ -5,7 +5,7 @@
 {% for name, definition in components.responses.items() %}
 
 ### {{name}}
-{% if definition.description %}{{definition.description | wordwrap(80)}}{% endif %}
+{% if definition.description %}{{definition.description}}{% endif %}
 
 {%- if definition.content %}
 {% with content = handler.simplify_content(definition.content) %}

--- a/openapidocs/mk/v3/views_mkdocs/partial/external-docs.html
+++ b/openapidocs/mk/v3/views_mkdocs/partial/external-docs.html
@@ -1,7 +1,7 @@
 ## {{texts.external_docs}}
 
 {% if externalDocs.description -%}
-{{externalDocs.description | wordwrap(80)}}
+{{externalDocs.description}}
 
 <hr />
 {%- endif -%}

--- a/openapidocs/mk/v3/views_mkdocs/partial/info.html
+++ b/openapidocs/mk/v3/views_mkdocs/partial/info.html
@@ -1,7 +1,7 @@
 # {{info.title}} <span class="api-version">{{info.version}}</span>
 
 {% if info.description -%}
-{{info.description | wordwrap(80)}}
+{{info.description}}
 <hr />
 {%- endif -%}
 

--- a/openapidocs/mk/v3/views_mkdocs/partial/path-items.html
+++ b/openapidocs/mk/v3/views_mkdocs/partial/path-items.html
@@ -7,13 +7,13 @@
 
 ### <span class="http-{{http_method.lower()}}">{{http_method.upper()}}</span> {{path | route | safe}}
 {% if "summary" in operation -%}
-{{operation.summary | wordwrap(80)}}
+{{operation.summary}}
 {%- endif -%}
 
 {%- if operation.description and operation.summary != operation.description %}
 
 ??? note "{{texts.description.title()}}"
-    {{operation.description | wordwrap(76) | indent(4)}}
+    {{operation.description | indent(4)}}
 {% endif %}
 
 {%- with parameters = handler.get_parameters(operation) -%}

--- a/tests/res/example1-output-plain.md
+++ b/tests/res/example1-output-plain.md
@@ -7,8 +7,7 @@ Most likely, it is not desirable to edit this file by hand!
 
 # Software Platform API v1
 
-Optional multiline or single-line description in
-[CommonMark](http://commonmark.org/help/) or HTML.
+Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
 
 ---
 
@@ -33,8 +32,7 @@ Optional multiline or single-line description in
 Initializes a file upload operation.
 
 **Description**
-The client receives a Shared Access Signature that can be used to upload a file
-directly to the Azure Storage Blob Service.
+The client receives a Shared Access Signature that can be used to upload a file directly to the Azure Storage Blob Service.
 
 **Input parameters**
 
@@ -98,8 +96,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "token": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -237,8 +234,7 @@ Gets the list of categories supported by the system.
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -260,8 +256,7 @@ _Other possible types: text/json, text/plain_
 
 
 ### GET /api/countries
-Gets a list of countries of the World with English dislay names and ISO country
-codes.
+Gets a list of countries of the World with English dislay names and ISO country codes.
 
 **Input parameters**
 
@@ -282,8 +277,7 @@ codes.
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -301,8 +295,7 @@ _Other possible types: text/json, text/plain_
 
 
 ### GET /api/system-countries
-Gets a list of countries supported by the system, with English dislay names and
-ISO country codes.
+Gets a list of countries supported by the system, with English dislay names and ISO country codes.
 
 **Input parameters**
 
@@ -323,8 +316,7 @@ ISO country codes.
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -452,8 +444,7 @@ Gets a paginated set of downloads records.
     "total": 26
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -505,8 +496,7 @@ API health check
     "regionName": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -579,8 +569,7 @@ _Other possible types: text/json, text/plain_
     "signature": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -632,8 +621,7 @@ Returns information about the API itself.
     "contactEmail": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -769,8 +757,7 @@ Returns details about a release by id.
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -898,8 +885,7 @@ Deletes a release by id.
     ]
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -1038,8 +1024,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1226,8 +1211,7 @@ _Other possible types: text/json, text/plain_
     "total": 26
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1278,8 +1262,7 @@ _Other possible types: text/json, text/plain_
     ]
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -1326,8 +1309,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "id": "00000000-0000-0000-0000-000000000000"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1373,8 +1355,7 @@ _Other possible types: text/json, text/plain_
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1416,8 +1397,7 @@ _Other possible types: text/json, text/plain_
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1520,8 +1500,7 @@ _Other possible types: text/json, text/plain_
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1558,8 +1537,7 @@ _Other possible types: text/json, text/plain_
     "url": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1600,8 +1578,7 @@ _Other possible types: text/json, text/plain_
     "uniqueDownloads": 26
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1646,8 +1623,7 @@ _Other possible types: text/json, text/plain_
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -1757,8 +1733,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -1869,8 +1844,7 @@ _Other possible types: text/json, text/plain_
     }
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -1980,8 +1954,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -2095,8 +2068,7 @@ _Other possible types: text/json, text/plain_
     ]
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -2212,8 +2184,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -2322,8 +2293,7 @@ _Other possible types: text/json, text/plain_
     "00000000-0000-0000-0000-000000000000"
 ]
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -2434,8 +2404,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -2628,8 +2597,7 @@ _Other possible types: text/json, text/plain_
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -2739,8 +2707,7 @@ _Other possible types: text/json, text/plain_
     "sendEmailNotifications": true
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 _Other accepted types: application/*+json, application/json-patch+json, text/json_
 
 **Schema of the request body**
@@ -2856,8 +2823,7 @@ _Other accepted types: application/*+json, application/json-patch+json, text/jso
     "organizations": null
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 _Other possible types: text/json, text/plain_
 
@@ -3389,8 +3355,7 @@ This base error type is used for all raised exceptions.
     "message": "string"
 }
 ```
-_This example has been generated automatically from the schema and it is not
-accurate. Refer to the schema for more information._
+_This example has been generated automatically from the schema and it is not accurate. Refer to the schema for more information._
 
 
 **Schema of the response body**

--- a/tests/res/example1-output.md
+++ b/tests/res/example1-output.md
@@ -7,8 +7,7 @@ Most likely, it is not desirable to edit this file by hand!
 
 # Software Platform API <span class="api-version">v1</span>
 
-Optional multiline or single-line description in
-[CommonMark](http://commonmark.org/help/) or HTML.
+Optional multiline or single-line description in [CommonMark](http://commonmark.org/help/) or HTML.
 <hr />
 <div class="terms-of-service info-data">
     <strong>Terms of service:</strong> <a href="http://example.com/terms/" target="_blank" rel="noopener noreferrer">http://example.com/terms/</a>
@@ -50,8 +49,7 @@ Optional multiline or single-line description in
 Initializes a file upload operation.
 
 ??? note "Description"
-    The client receives a Shared Access Signature that can be used to upload a
-    file directly to the Azure Storage Blob Service.
+    The client receives a Shared Access Signature that can be used to upload a file directly to the Azure Storage Blob Service.
 
 
 **Input parameters**
@@ -343,8 +341,7 @@ Gets the list of categories supported by the system.
 <hr class="operation-separator" />
 
 ### <span class="http-get">GET</span> /api/countries
-Gets a list of countries of the World with English dislay names and ISO country
-codes.
+Gets a list of countries of the World with English dislay names and ISO country codes.
 
 **Input parameters**
 
@@ -404,8 +401,7 @@ codes.
 <hr class="operation-separator" />
 
 ### <span class="http-get">GET</span> /api/system-countries
-Gets a list of countries supported by the system, with English dislay names and
-ISO country codes.
+Gets a list of countries supported by the system, with English dislay names and ISO country codes.
 
 **Input parameters**
 

--- a/tests/res/example4-split-output.md
+++ b/tests/res/example4-split-output.md
@@ -159,8 +159,7 @@ Invite a user
 Retrieve all users
 
 ??? note "Description"
-    Retrieve all users from your instance. Only available for the instance
-    owner.
+    Retrieve all users from your instance. Only available for the instance owner.
 
 
 **Input parameters**


### PR DESCRIPTION
wordwrap breaks long URLs and mermaid superfences code blocks inside operation/info/response descriptions. Removed from all mkdocs and markdown partial templates.