### PR TITLE
Fix jsonSchemaDialect should not have a default value (issue #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix [#49](https://github.com/Neoteroi/essentials-openapi/issues/49): support `$ref`
   values of the form `file.yaml#/fragment/path` (external file with JSON Pointer
   fragment), reported by @mbklein.
+- Fix [#55](https://github.com/Neoteroi/essentials-openapi/issues/55): `jsonSchemaDialect`
+  is not required and should not have a default value.
 
 ## [1.3.0] - 2025-11-19
 

--- a/openapidocs/v3.py
+++ b/openapidocs/v3.py
@@ -957,8 +957,8 @@ class OpenAPI(OpenAPIRoot):
     Attributes:
         openapi (str): The semantic version number of the OpenAPI Specification version.
         info (Info | None): Metadata about the API.
-        json_schema_dialect (str): The default value for the $schema keyword within Schema Objects contained
-                                  within this OAS document.
+        json_schema_dialect (str | None): The default value for the $schema keyword within Schema Objects contained
+                                  within this OAS document. Optional; if omitted, the dialect is not declared.
         paths (dict[str, PathItem] | None): The available paths and operations for the API.
         servers (list[Server] | None): An array of Server Objects that provide connectivity information
                                         to a target server.
@@ -971,7 +971,7 @@ class OpenAPI(OpenAPIRoot):
 
     openapi: str = "3.1.0"
     info: Info | None = None
-    json_schema_dialect: str = "https://json-schema.org/draft/2020-12/schema"
+    json_schema_dialect: str | None = None
     paths: dict[str, PathItem] | None = None
     servers: list[Server] | None = None
     components: Components | None = None

--- a/tests/test_v3.py
+++ b/tests/test_v3.py
@@ -172,7 +172,6 @@ class OpenAPIExample1(TestItem):
         info:
             title: Cats API
             version: 1.0.0
-        jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
         paths:
             /:
                 summary: summary
@@ -214,7 +213,6 @@ class OpenAPIExample1(TestItem):
                 "title": "Cats API",
                 "version": "1.0.0"
             },
-            "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
             "paths": {
                 "/": {
                     "summary": "summary"
@@ -613,7 +611,6 @@ class OpenAPIExample3(TestItem):
         info:
             title: Weather API
             version: 0.0.0-alpha
-        jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
         paths:
             /weather:
                 summary: Call current weather data for one location
@@ -683,7 +680,6 @@ class OpenAPIExample3(TestItem):
                 "title": "Weather API",
                 "version": "0.0.0-alpha"
             },
-            "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
             "paths": {
                 "/weather": {
                     "summary": "Call current weather data for one location",
@@ -831,7 +827,6 @@ openapi: 3.1.0
 info:
     title: Example API
     version: 0.0.0-alpha
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 paths:
     /:
         summary: Test the example snake_case properness
@@ -869,7 +864,6 @@ paths:
         "title": "Example API",
         "version": "0.0.0-alpha"
     },
-    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "paths": {
         "/": {
             "summary": "Test the example snake_case properness",
@@ -976,7 +970,6 @@ openapi: 3.1.0
 info:
     title: Example API
     version: 0.0.0-alpha
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 paths:
     /:
         summary: Test the example snake_case properness
@@ -1022,7 +1015,6 @@ paths:
         "title": "Example API",
         "version": "0.0.0-alpha"
     },
-    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "paths": {
         "/": {
             "summary": "Test the example snake_case properness",
@@ -1153,7 +1145,6 @@ openapi: 3.1.0
 info:
     title: Example API
     version: 0.0.0-alpha
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 paths:
     /:
         summary: Test the example snake_case properness
@@ -1208,7 +1199,6 @@ paths:
         "title": "Example API",
         "version": "0.0.0-alpha"
     },
-    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "paths": {
         "/": {
             "summary": "Test the example snake_case properness",
@@ -1399,7 +1389,6 @@ openapi: 3.1.0
 info:
     title: Example API
     version: 0.0.0-alpha
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 paths:
     /:
         description: Lorem ipsum dolor sit amet
@@ -1499,7 +1488,6 @@ components:
         "title": "Example API",
         "version": "0.0.0-alpha"
     },
-    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "paths": {
         "/": {
             "description": "Lorem ipsum dolor sit amet",
@@ -1697,7 +1685,6 @@ openapi: 3.1.0
 info:
     title: Example API
     version: 0.0.0-alpha
-jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
 paths:
     /:
         summary: Test the example snake_case properness
@@ -1743,7 +1730,6 @@ paths:
         "title": "Example API",
         "version": "0.0.0-alpha"
     },
-    "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
     "paths": {
         "/": {
             "summary": "Test the example snake_case properness",
@@ -1880,7 +1866,6 @@ class ServerExample1(TestItem):
     def yaml(self) -> str:
         return """
         openapi: 3.1.0
-        jsonSchemaDialect: https://json-schema.org/draft/2020-12/schema
         servers:
         -   url: https://{username}.gigantic-server.com:{port}/{basePath}
             description: The production API server
@@ -1902,7 +1887,6 @@ class ServerExample1(TestItem):
         return """
         {
             "openapi": "3.1.0",
-            "jsonSchemaDialect": "https://json-schema.org/draft/2020-12/schema",
             "servers": [
                 {
                     "url": "https://{username}.gigantic-server.com:{port}/{basePath}",


### PR DESCRIPTION
Changed the default for OpenAPI.json_schema_dialect from 'https://json-schema.org/draft/2020-12/schema' to None so that the field is omitted from serialized output unless explicitly set. Updated all test expectations accordingly.