### PR TITLE
Fix request body and response tabs merging into one tab group

### DIFF
--- a/openapidocs/mk/v3/views_mkdocs/partial/request-responses.html
+++ b/openapidocs/mk/v3/views_mkdocs/partial/request-responses.html
@@ -1,3 +1,5 @@
+<p class="responses-title"><strong>{{texts.responses}}</strong></p>
+
 {% for code, definition in operation.responses.items() %}
 === "{% if code == "default" %}{{texts.other_responses}}{% else %}{{code}}{% with phrase = get_http_status_phrase(code) %}{% if phrase %} {{ phrase }}{% endif %}{% endwith %}{% endif %}"
     {%- if is_reference(definition) -%}

--- a/tests/res/example1-output.md
+++ b/tests/res/example1-output.md
@@ -121,6 +121,8 @@ Initializes a file upload operation.
         }
         ```
 
+<p class="responses-title"><strong>Responses</strong></p>
+
 
 === "200 OK"
     
@@ -214,7 +216,9 @@ Gets the list of categories supported by the system.
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -345,7 +349,9 @@ Gets a list of countries of the World with English dislay names and ISO country 
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -405,7 +411,9 @@ Gets a list of countries supported by the system, with English dislay names and 
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -525,7 +533,9 @@ Gets a paginated set of downloads records.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -678,7 +688,9 @@ API health check
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -751,7 +763,9 @@ API health check
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -845,7 +859,9 @@ Returns information about the API itself.
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -927,7 +943,9 @@ Returns details about a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -1147,7 +1165,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
 
 <hr class="operation-separator" />
@@ -1249,6 +1269,8 @@ Deletes a release by id.
             "additionalProperties": false
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"
@@ -1519,7 +1541,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -1711,6 +1735,8 @@ Deletes a release by id.
         }
         ```
 
+<p class="responses-title"><strong>Responses</strong></p>
+
 
 === "200 OK"
     
@@ -1771,7 +1797,9 @@ Deletes a release by id.
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -1834,7 +1862,9 @@ Deletes a release by id.
             <td>Access token issued by Azure Active Directory.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -1905,7 +1935,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -2044,7 +2076,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -2120,7 +2154,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -2220,6 +2256,8 @@ Deletes a release by id.
             "nullable": true
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"
@@ -2470,6 +2508,8 @@ Deletes a release by id.
             "nullable": true
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"
@@ -2731,6 +2771,8 @@ Deletes a release by id.
         }
         ```
 
+<p class="responses-title"><strong>Responses</strong></p>
+
 
 === "200 OK"
     
@@ -2980,6 +3022,8 @@ Deletes a release by id.
         }
         ```
 
+<p class="responses-title"><strong>Responses</strong></p>
+
 
 === "200 OK"
     
@@ -3201,7 +3245,9 @@ Deletes a release by id.
             <td></td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -3456,6 +3502,8 @@ Deletes a release by id.
             "additionalProperties": false
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"

--- a/tests/res/example2-output.md
+++ b/tests/res/example2-output.md
@@ -78,7 +78,9 @@ List all pets
             <td>How many items to return at one time (max 100)</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -190,7 +192,9 @@ Create a pet
             <td>Basic authentication</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "201 Created"
 === "Other responses"
     
@@ -274,7 +278,9 @@ Info for a specific pet
             <td>The id of the pet to retrieve</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -419,6 +425,8 @@ Info for a specific pet
             ]
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"

--- a/tests/res/example3-output.md
+++ b/tests/res/example3-output.md
@@ -62,7 +62,9 @@ List all pets
             <td>How many items to return at one time (max 100)</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -141,7 +143,9 @@ List all pets
 <hr class="operation-separator" />
 
 ### <span class="http-post">POST</span> /pets
-Create a pet
+Create a pet<p class="responses-title"><strong>Responses</strong></p>
+
+
 === "201 Created"
 === "Other responses"
     
@@ -209,7 +213,9 @@ Info for a specific pet
             <td>The id of the pet to retrieve</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -321,6 +327,8 @@ Info for a specific pet
             ]
         }
         ```
+
+<p class="responses-title"><strong>Responses</strong></p>
 
 
 === "200 OK"

--- a/tests/res/example4-split-output.md
+++ b/tests/res/example4-split-output.md
@@ -109,6 +109,8 @@ Invite a user
         }
         ```
 
+<p class="responses-title"><strong>Responses</strong></p>
+
 
 === "200 OK"
     
@@ -201,7 +203,9 @@ Retrieve all users
             <td>The maximum number of items to return.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     
     === "application/json"
@@ -300,7 +304,9 @@ Get user by ID/Email
             <td>The ID or email of the user.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     <div class="common-response"><p>Refer to the common response description: <a href="#userinformation" class="ref-link">UserInformation</a>.</p></div>
 === "401 Unauthorized"
@@ -354,7 +360,9 @@ Delete user by ID/Email
             <td>ID of the user to transfer workflows and credentials to. Must not be equal to the to-be-deleted user.</td>
         </tr>
     </tbody>
-</table>
+</table><p class="responses-title"><strong>Responses</strong></p>
+
+
 === "200 OK"
     <div class="common-response"><p>Refer to the common response description: <a href="#userinformation" class="ref-link">UserInformation</a>.</p></div>
 === "401 Unauthorized"


### PR DESCRIPTION
pymdownx.tabbed treats consecutive === blocks separated by only whitespace as a single tab group. After issue #35, the content-type tabs in request-body and the response-code tabs in request-responses were both at column 0 with only blank lines between them, causing them to merge into one tab group.

Fix: add a <p class="responses-title"> heading before the responses tab loop in request-responses.html. This provides a non-tab line that breaks the tab group chain, keeping request body tabs and response tabs separate.